### PR TITLE
Ticket7217 b17t hardware test

### DIFF
--- a/b17tmagSup/b17tmag.db
+++ b/b17tmagSup/b17tmag.db
@@ -87,8 +87,8 @@ record(bi, "$(P)READY"){
     field(DTYP, "stream")
     field(SCAN, "1 second")
     field(INP, "@b17tmag.proto getReady $(PORT)")
-    field(ZNAM, "ON")
-    field(ONAM, "OFF")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
     info(archive, "VAL")
     info(interest, "HIGH")
 }

--- a/b17tmagSup/b17tmag.proto
+++ b/b17tmagSup/b17tmag.proto
@@ -1,7 +1,9 @@
 InTerminator = "\n";
 OutTerminator = "\n";
 
+LockTimeout = 3000;
 ReplyTimeout = 2000;
+ReadTimeout = 1000;
 
 getField {
     out "output";


### PR DESCRIPTION
For [#7217](https://github.com/ISISComputingGroup/IBEX/issues/7217)

Simple changes to increase reliability of comms and to switch behaviour of the ready PV. The only instrument to host this device whilst the unintuitive ready behaviour was present (ZOOM) did not have any blocks attached to ready, and no other PVs reference it.